### PR TITLE
Add function to update bashrc with tests

### DIFF
--- a/.github/workflows/test_update_bashrc.yaml
+++ b/.github/workflows/test_update_bashrc.yaml
@@ -1,0 +1,26 @@
+name: test_basic_alias
+
+on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+        type: string
+        default: "main"
+  workflow_call:
+    inputs:
+      git-ref:
+        required: false
+        type: string
+        default: "main"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git-ref }}
+      - name: test
+        run: |
+          . ./tests/test_update_bashrc.sh

--- a/.github/workflows/tests_on_push_branches.yaml
+++ b/.github/workflows/tests_on_push_branches.yaml
@@ -26,3 +26,7 @@ jobs:
     uses: ./.github/workflows/test_python_pyenv_alias_workflow_call.yaml
     with:
       git-ref: ${{ github.ref }}
+  test_update_bashrc:
+    uses: ./.github/workflows/test_update_bashrc.yaml
+    with:
+      git-ref: ${{ github.ref }}

--- a/.github/workflows/tests_on_schedule.yaml
+++ b/.github/workflows/tests_on_schedule.yaml
@@ -16,3 +16,5 @@ jobs:
     uses: ./.github/workflows/test_python_uv_alias_workflow_call.yaml
   test_python_pyenv_alias_workflow_call:
     uses: ./.github/workflows/test_python_pyenv_alias_workflow_call.yaml
+  test_update_bashrc:
+    uses: ./.github/workflows/test_update_bashrc.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .vscode
 ./test-*/
+
+# created for test
+.bashrc.alt
+.myalias.sh

--- a/myalias.sh
+++ b/myalias.sh
@@ -70,3 +70,32 @@ alias dcr='docker compose run'
 
 # vscode
 alias co='code'
+
+# Update bashrc
+update_my_bash_alias(){
+    # const.
+    _BASHRC=${1:-"~/.bashrc"}
+    _NEW_MYALIAS=".myalias.sh"
+    _START_LINE="######StartMyBashAlias######"
+    _END_LINE="######EndMyBashAlias######"
+    _URL=https://raw.githubusercontent.com/hmasdev/my-bash-alias/main/myalias.sh
+    # perparation
+    touch $_BASHRC
+    # download myalias.sh
+    curl -sf $_URL > $_NEW_MYALIAS
+    # branch if START_LINE or END_LINE do NOT exists
+    if ! grep -q "$START_LINE" $_BASHRC || ! grep -q "$END_LINE" $_BASHRC; then
+        echo "Adding alias to $_BASHRC"
+        # delete START_LINE and END_LINE
+        sed -i "s/$START_LINE//g" $_BASHRC
+        sed -i "s/$END_LINE//g" $_BASHRC
+        # add START_LINE, mybash.sh, and END_LINE
+        echo "$START_LINE" >> $_BASHRC
+        cat $_NEW_MYALIAS >> $_BASHRC
+        echo "$END_LINE" >> $_BASHRC
+    else
+        echo "Updating alias in $_BASHRC"
+        sed -i "/$START_LINE/,/$END_LINE/{//!d}" $_BASHRC  # delete lines between START_LINE and END_LINE
+        sed -i "/$START_LINE/r $_NEW_MYALIAS" $_BASHRC  # add new_content after START_LINE
+    fi
+}

--- a/tests/test_update_bashrc.sh
+++ b/tests/test_update_bashrc.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -l
+shopt -s expand_aliases
+set -xe
+# preparation
+BASHRC_ALT=./.bashrc.alt
+DUMMY_LINE="#DUMMYLINE_FOR_TEST"
+START_LINE="######StartMyBashAlias######"
+END_LINE="######EndMyBashAlias######"
+echo > $BASHRC_ALT
+source ./myalias.sh
+
+# test
+# CASE: initial call
+echo "CASE: initial call"
+# Initialize
+echo > $BASHRC_ALT
+# Call
+update_my_bash_alias $BASHRC_ALT
+# Assert
+grep "alias co='code'" $BASHRC_ALT
+
+# CASE: update call
+echo "CASE: update call"
+# Initialize
+echo > $BASHRC_ALT
+echo $START_LINE >> $BASHRC_ALT
+echo $DUMMY_LINE >> $BASHRC_ALT
+echo $END_LINE >> $BASHRC_ALT
+# Call
+update_my_bash_alias $BASHRC_ALT
+# Assert
+grep $DUMMY_LINE $BASHRC_ALT && exit 1 || echo "OK"
+grep "alias co='code'" $BASHRC_ALT
+
+# CASE: Only START_LINE exists
+echo "CASE: Only START_LINE exists"
+# Initialize
+echo > $BASHRC_ALT
+echo $START_LINE >> $BASHRC_ALT
+echo $DUMMY_LINE >> $BASHRC_ALT
+# Call
+update_my_bash_alias $BASHRC_ALT
+# Assert
+grep "$DUMMY_LINE" $BASHRC_ALT
+grep "alias co='code'" $BASHRC_ALT
+
+# CASE: Only END_LINE exists
+echo "CASE: Only END_LINE exists"
+# Initialize
+echo > $BASHRC_ALT
+echo $DUMMY_LINE >> $BASHRC_ALT
+echo $END_LINE >> $BASHRC_ALT
+# Call
+update_my_bash_alias $BASHRC_ALT
+# Assert
+grep "$DUMMY_LINE" $BASHRC_ALT
+grep "alias co='code'" $BASHRC_ALT


### PR DESCRIPTION
This pull request adds a new function to update the bashrc file with tests. The function, `update_my_bash_alias`, allows for updating the bashrc file with a new alias file, `.myalias.sh`, which can be downloaded from a specified URL. The function handles cases where the start and end lines for the aliases already exist in the bashrc file, as well as cases where only one of the lines exists. The pull request also includes a test script that verifies the functionality of the `update_my_bash_alias` function.