### PR TITLE
Add tar aliases to myalias.sh

### DIFF
--- a/.github/workflows/test_tar_alias_workflow_call.yaml
+++ b/.github/workflows/test_tar_alias_workflow_call.yaml
@@ -1,0 +1,26 @@
+name: test_tar_alias
+
+on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+        type: string
+        default: "main"
+  workflow_call:
+    inputs:
+      git-ref:
+        required: false
+        type: string
+        default: "main"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git-ref }}
+      - name: test
+        run: |
+          . ./tests/test_tar_alias.sh

--- a/.github/workflows/tests_on_push_branches.yaml
+++ b/.github/workflows/tests_on_push_branches.yaml
@@ -30,3 +30,7 @@ jobs:
     uses: ./.github/workflows/test_update_bashrc.yaml
     with:
       git-ref: ${{ github.ref }}
+  test_tar_alias_workflow_call:
+    uses: ./.github/workflows/test_tar_alias_workflow_call.yaml
+    with:
+      git-ref: ${{ github.ref }}

--- a/.github/workflows/tests_on_schedule.yaml
+++ b/.github/workflows/tests_on_schedule.yaml
@@ -18,3 +18,5 @@ jobs:
     uses: ./.github/workflows/test_python_pyenv_alias_workflow_call.yaml
   test_update_bashrc:
     uses: ./.github/workflows/test_update_bashrc.yaml
+  test_tar_alias_workflow_call:
+    uses: ./.github/workflows/test_tar_alias_workflow_call.yaml

--- a/myalias.sh
+++ b/myalias.sh
@@ -10,6 +10,11 @@ alias mkd='mkdir'
 alias psux='ps ux'
 alias wh='which'
 
+# tar
+alias tarc='tar -cvzf'
+alias tart='tar -tvzf'
+alias tarx='tar -xvzf'
+
 # git
 alias ga='git add'
 alias gb='git branch'

--- a/tests/test_tar_alias.sh
+++ b/tests/test_tar_alias.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -l
+shopt -s expand_aliases
+set -e
+# const
+test_workspace="./test-tar_workspace"
+test_direc="./test-directory"
+test_file1="hoge.txt"
+test_file2="fuga.txt"
+# setup
+source ./myalias.sh
+
+rm -rf $test_workspace || echo "$test_workspace not found"
+mkdir -p $test_workspace
+pushd $test_workspace
+
+mkd $test_direc
+echo $test_file1 > $test_direc/$test_file1
+echo $test_file2 > $test_direc/$test_file2
+
+tarc $test_direc.tar.gz $test_direc
+tart $test_direc.tar.gz
+rm -r $test_direc
+tarx $test_direc.tar.gz
+
+popd


### PR DESCRIPTION
This pull request adds tar aliases to the myalias.sh file. The aliases include tarc, tart, and tarx, which are used for creating, listing, and extracting tar files respectively. The changes also include a new bash script for testing the tar aliases, which creates a test directory, creates a tar file from the directory, lists the contents of the tar file, deletes the directory, and then extracts the contents of the tar file.