### PR TITLE
Add uvenv alias to myalias.sh

### DIFF
--- a/myalias.sh
+++ b/myalias.sh
@@ -66,6 +66,7 @@ alias upip='uv pip'
 alias uva='uv add'
 alias uvs='uv sync'
 alias uvr='uv run'
+alias uvenv='uv venv'
 
 # npm
 alias npmi='npm install'

--- a/tests/test_python_uv_alias.sh
+++ b/tests/test_python_uv_alias.sh
@@ -16,4 +16,9 @@ upip install schedule
 uvs
 uvr which python
 
+rm -rf .venv
+uvenv
+upip install requests
+uvr which python
+
 popd


### PR DESCRIPTION
This pull request adds the `uvenv` alias to the `myalias.sh` file. The alias allows for easy activation of a virtual environment using the `uv venv` command.