### PR TITLE
Update GitHub Actions workflows to use latest actions and add permissions

### DIFF
--- a/.github/workflows/test_basic_alias_workflow_call.yaml
+++ b/.github/workflows/test_basic_alias_workflow_call.yaml
@@ -17,8 +17,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-ref }}
       - name: test

--- a/.github/workflows/test_git_alias_workflow_call.yaml
+++ b/.github/workflows/test_git_alias_workflow_call.yaml
@@ -17,8 +17,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-ref }}
       - name: Setup

--- a/.github/workflows/test_python_alias_workflow_call.yaml
+++ b/.github/workflows/test_python_alias_workflow_call.yaml
@@ -17,12 +17,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-ref }}
       - name: Set up Python "3.11"
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: test

--- a/.github/workflows/test_python_pyenv_alias_workflow_call.yaml
+++ b/.github/workflows/test_python_pyenv_alias_workflow_call.yaml
@@ -17,8 +17,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-ref }}
       - name: Setup

--- a/.github/workflows/test_python_uv_alias_workflow_call.yaml
+++ b/.github/workflows/test_python_uv_alias_workflow_call.yaml
@@ -17,12 +17,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-ref }}
       - name: Set up Python "3.11"
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install requirements

--- a/.github/workflows/test_tar_alias_workflow_call.yaml
+++ b/.github/workflows/test_tar_alias_workflow_call.yaml
@@ -17,8 +17,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-ref }}
       - name: test

--- a/.github/workflows/test_update_bashrc.yaml
+++ b/.github/workflows/test_update_bashrc.yaml
@@ -17,8 +17,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-ref }}
       - name: test

--- a/.github/workflows/tests_on_push_branches.yaml
+++ b/.github/workflows/tests_on_push_branches.yaml
@@ -10,27 +10,41 @@ jobs:
     uses: ./.github/workflows/test_basic_alias_workflow_call.yaml
     with:
       git-ref: ${{ github.ref }}
+    permissions:
+      contents: read
   test_git_alias_workflow_call:
     uses: ./.github/workflows/test_git_alias_workflow_call.yaml
     with:
       git-ref: ${{ github.ref }}
+    permissions:
+      contents: read
   test_python_alias_workflow_call:
     uses: ./.github/workflows/test_python_alias_workflow_call.yaml
     with:
       git-ref: ${{ github.ref }}
+    permissions:
+      contents: read
   test_python_uv_alias_workflow_call:
     uses: ./.github/workflows/test_python_uv_alias_workflow_call.yaml
     with:
       git-ref: ${{ github.ref }}
+    permissions:
+      contents: read
   test_python_pyenv_alias_workflow_call:
     uses: ./.github/workflows/test_python_pyenv_alias_workflow_call.yaml
     with:
       git-ref: ${{ github.ref }}
+    permissions:
+      contents: read
   test_update_bashrc:
     uses: ./.github/workflows/test_update_bashrc.yaml
     with:
       git-ref: ${{ github.ref }}
+    permissions:
+      contents: read
   test_tar_alias_workflow_call:
     uses: ./.github/workflows/test_tar_alias_workflow_call.yaml
     with:
       git-ref: ${{ github.ref }}
+    permissions:
+      contents: read

--- a/.github/workflows/tests_on_schedule.yaml
+++ b/.github/workflows/tests_on_schedule.yaml
@@ -8,15 +8,29 @@ on:
 jobs:
   test_basic_alias_workflow_call:
     uses: ./.github/workflows/test_basic_alias_workflow_call.yaml
+    permissions:
+      contents: read
   test_git_alias_workflow_call:
     uses: ./.github/workflows/test_git_alias_workflow_call.yaml
+    permissions:
+      contents: read
   test_python_alias_workflow_call:
     uses: ./.github/workflows/test_python_alias_workflow_call.yaml
+    permissions:
+      contents: read
   test_python_uv_alias_workflow_call:
     uses: ./.github/workflows/test_python_uv_alias_workflow_call.yaml
+    permissions:
+      contents: read
   test_python_pyenv_alias_workflow_call:
     uses: ./.github/workflows/test_python_pyenv_alias_workflow_call.yaml
+    permissions:
+      contents: read
   test_update_bashrc:
     uses: ./.github/workflows/test_update_bashrc.yaml
+    permissions:
+      contents: read
   test_tar_alias_workflow_call:
     uses: ./.github/workflows/test_tar_alias_workflow_call.yaml
+    permissions:
+      contents: read


### PR DESCRIPTION
Upgrade the GitHub Actions workflows to utilize `actions/checkout@v4` and `actions/setup-python@v5`, while also adding necessary permissions for content access.